### PR TITLE
Fix the "can't concat NoneType to bytes" error

### DIFF
--- a/model_class.py
+++ b/model_class.py
@@ -73,7 +73,8 @@ def callback_impl(result, userdata, state):
                 print((split_byte_data + result.contents.text).decode('utf-8'), end='')
                 split_byte_data = bytes(b"")
         except:
-            split_byte_data += result.contents.text
+            if result.contents.text is not None:
+                split_byte_data += result.contents.text
         sys.stdout.flush()
 
 # Connect the callback function between the Python side and the C++ side


### PR DESCRIPTION
Fix the following error mess up with the console output:

```python
Traceback (most recent call last):
  File "/root/rkllm-gradio/model_class.py", line 76, in callback_impl
    split_byte_data += result.contents.text
TypeError: can't concat NoneType to bytes
```