### PR TITLE
Docker container, Better Chat window size, Offline tokenizers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+models
+assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.12-bookworm
 WORKDIR /app
-COPY . /app
-RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+COPY . /app
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-bookworm
 WORKDIR /app
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
-COPY ./requirements.txt /app/requirements.txt
+COPY ./requirements.txt ./setup.sh /app/requirements.txt
 RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-bookworm
 WORKDIR /app
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
 COPY ./requirements.txt ./setup.sh /app/
-RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY . /app
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-bookworm
 WORKDIR /app
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
-COPY ./requirements.txt ./setup.sh /app/requirements.txt
+COPY ./requirements.txt ./setup.sh /app/
 RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-bookworm
+WORKDIR /app
+COPY . /app
+RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ And chat:
 
 ![chat](assets/chat.png)
 
+## Docker container 
+
+The image has to be run with "--privileged" or the application will not be able to access the NPU. The models are not included in the image. Change the -v flag to point to the models folder. 
+```
+sudo docker run -d -p 8080:8080 --privileged -v /location/of/your/models:/app/models --name rkllm martivo/rkllm-gradio:latest
+```
+
+View logs with
+```
+sudo docker logs -f rkllm
+```
+
+Stop and remove the container
+```
+sudo docker rm -f rkllm
+```
+
+Build Your own image
+```
+sudo  docker build -t martivo/rkllm-gradio:latest .
+```
+
+
+
 ## Default Version
 
 The default version of the RKLLM library, in `./lib/` is 1.1.2. To change to 1.1.1:

--- a/model_class.py
+++ b/model_class.py
@@ -173,7 +173,13 @@ class RKLLMLoaderClass:
                 user_prompt
             ]
         # print(prompt)
-        tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
+        TOKENIZER_PATH="%s/%s"%(MODEL_PATH,self.st_model_id.replace("/","-"))
+        if not os.path.exists(TOKENIZER_PATH):
+            os.mkdir(TOKENIZER_PATH)
+            tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
+            tokenizer.save_pretrained(TOKENIZER_PATH)
+        else
+            tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH, trust_remote_code=True)
         prompt = tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True)
         # response = {"role": "assistant", "content": "Loading..."}
         response = {"role": "assistant", "content": ""}

--- a/model_class.py
+++ b/model_class.py
@@ -175,6 +175,7 @@ class RKLLMLoaderClass:
         # print(prompt)
         TOKENIZER_PATH="%s/%s"%(MODEL_PATH,self.st_model_id.replace("/","-"))
         if not os.path.exists(TOKENIZER_PATH):
+            print("Tokenizer not cached locally, downloading to %s"%TOKENIZER_PATH)
             os.mkdir(TOKENIZER_PATH)
             tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
             tokenizer.save_pretrained(TOKENIZER_PATH)

--- a/model_class.py
+++ b/model_class.py
@@ -178,7 +178,7 @@ class RKLLMLoaderClass:
             os.mkdir(TOKENIZER_PATH)
             tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
             tokenizer.save_pretrained(TOKENIZER_PATH)
-        else
+        else:
             tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH, trust_remote_code=True)
         prompt = tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True)
         # response = {"role": "assistant", "content": "Loading..."}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-gradio==5.6.0
-gradio_client==1.4.3
+gradio==5.14.0
+gradio_client==1.7.0
 huggingface-hub==0.26.2
 Jinja2==3.1.4
 numpy==2.1.3

--- a/rkllm_server_gradio.py
+++ b/rkllm_server_gradio.py
@@ -55,10 +55,14 @@ if __name__ == "__main__":
                 model_dropdown.input(initialize_model, [model_dropdown], [statusBox])
             with gr.TabItem("Txt2Txt"):
                 txt2txt = gr.ChatInterface(fn=get_RKLLM_output, type="messages")
+                txt2txt.chatbot.height = "70vh"
+                txt2txt.chatbot.resizeable = True
             with gr.TabItem("Txt2Mesh"):
                 with gr.Row():    
                     with gr.Column(scale=2):
                         txt2txt = gr.ChatInterface(fn=get_RKLLM_output, type="messages")
+                        txt2txt.chatbot.height = "70vh"
+                        txt2txt.chatbot.resizeable = True
                     with gr.Column(scale=2):
                         # Add the text box for 3D mesh input and button
                         mesh_input = gr.Textbox(


### PR DESCRIPTION
I have added a Dockerfile with instructions on how to build and run.
The chat window was fixed at 200px height before. I updated Gradio library and made the chat window re-sizable and relative to screen size.
I also added cache for tokenizers. If Huggingface is offline or there is no access to internet the application can not work with only the model files. Now it saves the tokenizer to the models folder if it is not found, when it is found it uses the cached tokenizer. Now the application can work offline.